### PR TITLE
Update dragend.js

### DIFF
--- a/dragend.js
+++ b/dragend.js
@@ -425,7 +425,7 @@
 
         if ( Math.abs(parsedEvent.distanceX) > this.settings.minDragDistance || Math.abs(parsedEvent.distanceY) > this.settings.minDragDistance) {
           this.swipe( parsedEvent.direction );
-        } else if (parsedEvent.distanceX > 0 || parsedEvent.distanceX > 0) {
+        } else {
           this._scrollToPage();
         }
 


### PR DESCRIPTION
With this modification it fixes the bug related to repositioning the slide back to the original place if a backwards swipe doesn't reach the threshold, as this bug doesn't occur when swiping forward, but it does when sliding back.
