### PR TITLE
Add direction to onSwipeStart callback so one can predict the target page

### DIFF
--- a/dragend.js
+++ b/dragend.js
@@ -774,7 +774,7 @@
 
       swipe: function( direction ) {
         // Call onSwipeStart callback function
-        this.settings.onSwipeStart.call( this, this.container, this.activeElement, this.page + 1 );
+        this.settings.onSwipeStart.call( this, this.container, this.activeElement, this.page + 1, direction );
         this._scrollToPage( direction );
       },
 


### PR DESCRIPTION
This way I can do
```js
var dragend = new Dragend(document.getElementById('content'), {
	'onSwipeStart': function(container, activeElement, page, direction) {
		if (direction == 'left' || direction == 'down') {
			page = page + 1;
		} else if (direction == 'right' || direction == 'up') {
			page = page - 1;
		} else {
			return;
		}
		doSomethingToTargetPage(page);
	}
});
```