### PR TITLE
Enable setting the default page to load

### DIFF
--- a/dragend.js
+++ b/dragend.js
@@ -247,7 +247,7 @@
       this.container     = container;
       this.pageContainer = doc.createElement( "div" );
       this.scrollBorder  = { x: 0, y: 0 };
-      this.page          = 0;
+      this.page          = this.settings.page;
       this.preventScroll = false;
       this.pageCssProperties = {
         margin: 0


### PR DESCRIPTION
Currently when doing `new Dragend({page: 3})` the first page shown will be page 1. This enables the first page to be configured from the options when instantiating a new instance.
