### PR TITLE
Fix swiping left less than minimum drag distance

### DIFF
--- a/dragend.js
+++ b/dragend.js
@@ -438,6 +438,9 @@
         } else if (Math.abs(parsedEvent.distanceX) > 0 || Math.abs(parsedEvent.distanceY) > 0) {
           this._scrollToPage();
         }
+        else {
+          this._scrollToPage();
+        }
 
         this.settings.onDragEnd.call( this, this.container, this.activeElement, this.page + 1, event );
 


### PR DESCRIPTION
This fixes the bug that occurs when you try to swipe left, but don't drag far enough and the page gets stuck.